### PR TITLE
feat: add dark theme support with theme switcher

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,11 +4,14 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '@repo/frontend-utils/src/translation/i18n';
+import { ThemeProvider } from '@repo/ui/components/ThemeProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <I18nextProvider i18n={i18n}>
-      <App/>
+      <ThemeProvider>
+        <App/>
+      </ThemeProvider>
     </I18nextProvider>
   </StrictMode>,
 );

--- a/packages/ui/components/AuthForms.tsx
+++ b/packages/ui/components/AuthForms.tsx
@@ -292,7 +292,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
     return (
       <Card className="p-4 sm:p-6 w-full space-y-3 sm:space-y-4 text-center">
         <h2 className="text-xl sm:text-2xl font-bold">{t('thanksForRegistering')} 🎉</h2>
-        <p className="text-xs sm:text-sm text-gray-700">
+        <p className="text-xs sm:text-sm text-muted-foreground">
           {t('confirmationEmailSent')}
         </p>
 

--- a/packages/ui/components/AvatarTalkingHead.tsx
+++ b/packages/ui/components/AvatarTalkingHead.tsx
@@ -135,10 +135,10 @@ export const AvatarTalkingHead = forwardRef<
     <div
       ref={avatarContainerRef}
       style={{ maxHeight: '550px' }}
-      className="w-full h-full bg-gray-900 rounded-lg shadow-md"
+      className="w-full h-full bg-card text-card-foreground rounded-lg shadow-md border border-border"
     >
       {!isAvatarLoaded && (
-        <div className="flex items-center justify-center h-full text-white">
+        <div className="flex items-center justify-center h-full text-foreground">
           <Loader className="animate-spin mr-2" size={20}/>
           <span>{loadingMessage}</span>
         </div>

--- a/packages/ui/components/ChatMessages.tsx
+++ b/packages/ui/components/ChatMessages.tsx
@@ -30,7 +30,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
   chatStyle = 'voice',
   isConnected = true,
   emptyStateMessage,
-  className = 'h-64 overflow-y-auto p-4 border-2 border-gray-400 rounded-lg',
+  className = 'h-64 overflow-y-auto p-4 border border-border rounded-lg bg-card text-card-foreground',
 }) => {
   const { t } = useTypedTranslation();
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -61,8 +61,8 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
           key={index}
           className={`p-3 rounded-lg ${
             msg.role === 'user' ?
-              'bg-blue-100 text-blue-800 ml-8' :
-              'bg-gray-100 text-gray-800 mr-8'
+              'bg-primary/20 text-primary ml-8' :
+              'bg-muted text-foreground mr-8'
           }`}
         >
           <div className="font-semibold mb-1">
@@ -73,7 +73,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
       ))}
 
       {currentTranscript && currentTranscript !== lastMessageContent && (
-        <div className="p-3 rounded-lg bg-blue-50 text-blue-800 ml-8 border border-blue-200">
+        <div className="p-3 rounded-lg bg-primary/10 text-primary ml-8 border border-primary/30">
           <div className="font-semibold mb-1">
             {t('you')} ({t('listeningActive')})
           </div>
@@ -82,7 +82,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
       )}
 
       {assistantTranscript && (
-        <div className="p-3 rounded-lg bg-gray-50 text-gray-800 mr-8 border border-gray-200">
+        <div className="p-3 rounded-lg bg-muted text-foreground mr-8 border border-border">
           <div className="font-semibold mb-1">
             {assistantName} ({t('listeningActive')})
           </div>
@@ -91,16 +91,16 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
       )}
 
       {isProcessing && !currentTranscript && !assistantTranscript && (
-        <div className="bg-gray-100 text-gray-800 p-3 rounded-lg mr-8">
+        <div className="bg-muted text-muted-foreground p-3 rounded-lg mr-8">
           <div className="font-semibold mb-1">{t('aiProcessing')}</div>
           <div className="flex space-x-2">
-            <div className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"></div>
+            <div className="w-2 h-2 bg-foreground/50 rounded-full animate-bounce"></div>
             <div
-              className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+              className="w-2 h-2 bg-foreground/50 rounded-full animate-bounce"
               style={{ animationDelay: '0.2s' }}
             ></div>
             <div
-              className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+              className="w-2 h-2 bg-foreground/50 rounded-full animate-bounce"
               style={{ animationDelay: '0.4s' }}
             ></div>
           </div>
@@ -119,8 +119,8 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
           <div
             className={`max-w-[70%] p-3 rounded-lg ${
               msg.role === 'user' ?
-                'bg-blue-500 text-white rounded-br-none' :
-                'bg-gray-200 text-gray-800 rounded-bl-none'
+                'bg-primary text-primary-foreground rounded-br-none' :
+                'bg-muted text-foreground rounded-bl-none'
             }`}
           >
             <div className="flex justify-between items-start">
@@ -128,7 +128,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
               {msg.role === 'assistant' && msg.audioUrl && onPlayAudio && (
                 <button
                   onClick={() => onPlayAudio(msg, index)}
-                  className="ml-1 p-1 rounded-full hover:bg-gray-300 transition-colors"
+                  className="ml-1 p-1 rounded-full hover:bg-muted/80 transition-colors"
                   title={
                     isAudioPlaying ? t('chat.stopRecording') : t('chat.startRecording')
                   }
@@ -146,7 +146,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
             {msg.timestamp && (
               <p
                 className={`text-xs mt-1 ${
-                  msg.role === 'user' ? 'text-blue-100' : 'text-gray-500'
+                  msg.role === 'user' ? 'text-primary-foreground/80' : 'text-muted-foreground'
                 }`}
               >
                 {msg.timestamp.toLocaleTimeString([], {
@@ -161,18 +161,18 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 
       {isAiTyping && (
         <div className="flex justify-start">
-          <div className="bg-gray-200 text-gray-800 p-3 rounded-lg rounded-bl-none max-w-[70%]">
+          <div className="bg-muted text-foreground p-3 rounded-lg rounded-bl-none max-w-[70%]">
             <div className="flex space-x-1">
               <div
-                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-foreground/50 rounded-full animate-bounce"
                 style={{ animationDelay: '0s' }}
               ></div>
               <div
-                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-foreground/50 rounded-full animate-bounce"
                 style={{ animationDelay: '0.2s' }}
               ></div>
               <div
-                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-foreground/50 rounded-full animate-bounce"
                 style={{ animationDelay: '0.4s' }}
               ></div>
             </div>
@@ -188,7 +188,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
             !currentTranscript &&
             !assistantTranscript &&
             !isAiTyping ? (
-          <div className="text-gray-500 text-center py-8">
+          <div className="text-muted-foreground text-center py-8">
             {emptyStateMessage || defaultEmptyStateMessage}
           </div>
         ) : chatStyle === 'voice' ? (

--- a/packages/ui/components/ConversationRoleSelector.tsx
+++ b/packages/ui/components/ConversationRoleSelector.tsx
@@ -52,7 +52,7 @@ export const ConversationRoleSelector: React.FC<ConversationRoleSelectorProps> =
           <Button
             key={conversationRole.id}
             variant={isSelected ? 'default' : 'outline'}
-            className={isSelected ? 'bg-gray-800 text-white hover:bg-gray-700' : 'border-gray-500 hover:bg-gray-700'}
+            className={isSelected ? 'hover:bg-primary/90' : 'hover:bg-muted/60'}
             onClick={() => selectUserRole(conversationRole)}
           >
             {name}
@@ -65,7 +65,7 @@ export const ConversationRoleSelector: React.FC<ConversationRoleSelectorProps> =
           id="custom-user-role"
           value={customRoleName}
           onChange={handleCustomUserRoleChange}
-          className={`bg-transparent border-2 ${customRoleName ? 'border-black' : 'border-gray-400'}`}
+          className={`bg-transparent border-2 ${customRoleName ? 'border-primary' : 'border-border'}`}
           placeholder={t('enterCustomRolePlaceholder')}
         />
       </div>

--- a/packages/ui/components/ConversationTranscriptDialog.tsx
+++ b/packages/ui/components/ConversationTranscriptDialog.tsx
@@ -149,14 +149,14 @@ export const ConversationTranscriptDialog: React.FC<ConversationTranscriptDialog
           )}
 
           {mode === 'chat' && (description || defaultDescription) && (
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               {description || defaultDescription}
             </p>
           )}
         </DialogHeader>
 
         {mode === 'chat' && endedDueToTimeLimit && (
-          <div className="mb-4 p-3 bg-yellow-100 text-yellow-800 rounded-lg">
+          <div className="mb-4 p-3 bg-amber-200/60 text-amber-900 dark:text-amber-200 rounded-lg">
             {t('chat.timeLimit', {
               defaultValue: 'Chat ended after reaching the 5-minute time limit.',
             })}
@@ -164,7 +164,7 @@ export const ConversationTranscriptDialog: React.FC<ConversationTranscriptDialog
         )}
 
         {mode === 'chat' && isSavingConversation && (
-          <div className="mb-4 p-3 bg-blue-100 text-blue-800 rounded-lg">
+          <div className="mb-4 p-3 bg-primary/20 text-primary rounded-lg">
             {t('chat.savingConversation', {
               defaultValue: 'Saving conversation...',
             })}
@@ -187,10 +187,10 @@ export const ConversationTranscriptDialog: React.FC<ConversationTranscriptDialog
                   msg.role === 'assistant' ?
                     mode === 'admin' ?
                       'bg-muted text-foreground' :
-                      'bg-gray-100 text-gray-800' :
+                      'bg-muted text-foreground' :
                     mode === 'admin' ?
                       'bg-primary/10 text-foreground' :
-                      'bg-blue-100 text-blue-800'
+                      'bg-primary/20 text-primary'
                 }`}>
                   {msg.content}
                 </p>

--- a/packages/ui/components/Header.tsx
+++ b/packages/ui/components/Header.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from '../hooks/useAppStore';
 import { isProfileAdmin } from '@repo/shared/utils/access';
 import { useTypedTranslation } from '../hooks/useTypedTranslation';
 import { createInitials } from '@repo/shared/utils/usernameUtils';
+import { ThemeSwitcher } from './ThemeSwitcher';
 
 export function Header() {
   const { i18n } = useTypedTranslation();
@@ -39,7 +40,7 @@ export function Header() {
   };
 
   return (
-    <header className="py-4 px-4 sm:px-6 shadow-md mb-4">
+    <header className="py-4 px-4 sm:px-6 shadow-md mb-4 bg-background border-b border-border">
       <div className="container mx-auto flex justify-between items-center">
         <h1 className="text-2xl font-bold">
           <Link to="/">{app_name}</Link>
@@ -49,6 +50,7 @@ export function Header() {
 
         {/* Desktop */}
         <div className="items-center flex-wrap gap-2 hidden sm:flex">
+          <ThemeSwitcher className="shrink-0"/>
           <LanguageSelector
             availableLangs={availableLangs}
             currentLang={currentLang}
@@ -77,6 +79,7 @@ export function Header() {
 
         {/* Mobile menu */}
         <MobileMenuDrawer open={menuOpen} onClose={() => setMenuOpen(false)}>
+          <ThemeSwitcher fullWidth className="w-full"/>
           <LanguageSelector
             availableLangs={availableLangs}
             currentLang={currentLang}
@@ -113,13 +116,13 @@ export function Header() {
 
 const BurgerButton: React.FC<{ open: boolean; onToggle: () => void }> = ({ open, onToggle }) => (
   <button
-    className="sm:hidden flex flex-col justify-center items-center w-10 h-10 rounded focus:outline-none"
+    className="sm:hidden flex flex-col justify-center items-center w-10 h-10 rounded focus:outline-none text-foreground"
     aria-label={open ? 'Close menu' : 'Open menu'}
     onClick={onToggle}
   >
-    <span className={`block w-6 h-0.5 bg-black mb-1 transition-all ${open ? 'rotate-45 translate-y-1.5' : ''}`}/>
-    <span className={`block w-6 h-0.5 bg-black mb-1 transition-all ${open ? 'opacity-0' : ''}`}/>
-    <span className={`block w-6 h-0.5 bg-black transition-all ${open ? '-rotate-45 -translate-y-1.5' : ''}`}/>
+    <span className={`block w-6 h-0.5 bg-foreground mb-1 transition-all ${open ? 'rotate-45 translate-y-1.5' : ''}`}/>
+    <span className={`block w-6 h-0.5 bg-foreground mb-1 transition-all ${open ? 'opacity-0' : ''}`}/>
+    <span className={`block w-6 h-0.5 bg-foreground transition-all ${open ? '-rotate-45 -translate-y-1.5' : ''}`}/>
   </button>
 );
 
@@ -135,14 +138,14 @@ const LanguageSelector: React.FC<{
   return (
     <Select value={currentLang.ISO639} onValueChange={onChange}>
       <SelectTrigger
-        className={`${compact ? 'w-24' : 'w-full'} bg-white ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+        className={`${compact ? 'w-24' : 'w-full'} bg-background ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
         disabled={disabled}
         title={disabled ? (t?.('languageChangeDisabledInChat') ?? 'Language change is disabled inside a chat thread.') : undefined}
         aria-disabled={disabled}
       >
         <SelectValue placeholder={currentLang.NATIVE_NAME.toUpperCase()}/>
       </SelectTrigger>
-      <SelectContent className="bg-white">
+      <SelectContent>
         {availableLangs.map((lang) => (
           <SelectItem key={lang.ISO639} value={lang.ISO639} disabled={disabled}>
             {lang.NATIVE_NAME} {lang.ISO639 === 'sk' ? t('slovakLanguageNote') : ''}
@@ -216,9 +219,9 @@ const MobileMenuDrawer: React.FC<{
 }> = ({ open, onClose, children }) => {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 sm:hidden" onClick={onClose}>
+    <div className="fixed inset-0 z-50 bg-foreground/20 sm:hidden" onClick={onClose}>
       <div
-        className="absolute top-0 right-0 w-64 h-full bg-white shadow-lg p-4 flex flex-col gap-4"
+        className="absolute top-0 right-0 w-64 h-full bg-background border-l border-border shadow-lg p-4 flex flex-col gap-4"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-end">

--- a/packages/ui/components/PersonalityInfo.tsx
+++ b/packages/ui/components/PersonalityInfo.tsx
@@ -14,7 +14,7 @@ export const PersonalityInfo: React.FC<PersonalityInfoProps> = ({
   personality,
   conversationRole,
   connectionStatus,
-  className = 'border-2 border-gray-400 rounded-lg p-6',
+  className = 'border border-border rounded-lg p-6 bg-card text-card-foreground',
 }) => {
   const { t, language } = useTypedTranslation();
   const problemSummary = language === LANGUAGE.EN ? personality.problem_summary_en : personality.problem_summary_cs;

--- a/packages/ui/components/ResetPasswordRequestForm.tsx
+++ b/packages/ui/components/ResetPasswordRequestForm.tsx
@@ -37,7 +37,7 @@ export const ResetPasswordRequestForm: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4 sm:py-12 sm:px-6">
+    <div className="min-h-screen flex items-center justify-center bg-background py-8 px-4 sm:py-12 sm:px-6">
 
       <Card className="p-4 sm:p-6 w-full max-w-md">
         <h2 className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 text-center">
@@ -45,7 +45,7 @@ export const ResetPasswordRequestForm: React.FC = () => {
         </h2>
 
         {message ? (
-          <p className="text-center text-xs sm:text-sm text-green-600">{message}</p>
+          <p className="text-center text-xs sm:text-sm text-emerald-600 dark:text-emerald-400">{message}</p>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
@@ -60,7 +60,7 @@ export const ResetPasswordRequestForm: React.FC = () => {
               />
             </div>
 
-            {error && <p className="text-red-500 text-sm">{error}</p>}
+            {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
 
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? t('loading.general') : t('sendResetLink', 'Send reset link')}

--- a/packages/ui/components/ScenarioInfo.tsx
+++ b/packages/ui/components/ScenarioInfo.tsx
@@ -15,7 +15,7 @@ export const ScenarioInfo: React.FC<ScenarioInfoProps> = ({
 
   if (!scenario) {
     return (
-      <div className="flex-1 border-2 border-gray-400 rounded-lg p-6 bg-gray-50">
+      <div className="flex-1 border border-border rounded-lg p-6 bg-card text-card-foreground">
         <h2 className="text-xl font-semibold mb-2">{t('scenario')}</h2>
         <p className="text-sm">{t('noScenarioSelected')}</p>
       </div>
@@ -24,7 +24,7 @@ export const ScenarioInfo: React.FC<ScenarioInfoProps> = ({
   const { situationDescription, setting } = universalDescriptionForScenario(scenario, language);
 
   return (
-    <div className="flex-1 border-2 border-gray-400 rounded-lg p-6 bg-gray-50">
+    <div className="flex-1 border border-border rounded-lg p-6 bg-card text-card-foreground">
       <h2 className="text-xl font-semibold mb-2">{t('scenario')}</h2>
       {setting && <p className="italic text-sm mb-1">{setting}</p>}
       <p className="text-sm whitespace-pre-wrap">

--- a/packages/ui/components/ThemeProvider.tsx
+++ b/packages/ui/components/ThemeProvider.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+interface ThemeProviderProps {
+    children: React.ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}
+

--- a/packages/ui/components/ThemeSwitcher.tsx
+++ b/packages/ui/components/ThemeSwitcher.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { cn } from '../lib/utils';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select';
+
+const THEME_OPTIONS = [
+  { value: 'system', label: 'System', Icon: Monitor },
+  { value: 'light', label: 'Light', Icon: Sun },
+  { value: 'dark', label: 'Dark', Icon: Moon },
+] as const;
+
+type ThemeValue = (typeof THEME_OPTIONS)[number]['value'];
+
+interface ThemeSwitcherProps {
+    className?: string;
+    fullWidth?: boolean;
+}
+
+export function ThemeSwitcher({ className, fullWidth }: ThemeSwitcherProps) {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const selectedValue = (mounted ? theme : undefined) ?? 'system';
+
+  const ActiveIcon = useMemo(() => {
+    if (!mounted) return Monitor;
+    if (resolvedTheme === 'dark') return Moon;
+    return Sun;
+  }, [mounted, resolvedTheme]);
+
+  return (
+    <Select value={selectedValue} onValueChange={(value: ThemeValue) => setTheme(value)}>
+      <SelectTrigger
+        size="sm"
+        className={cn(
+          'justify-between gap-2',
+          fullWidth ? 'w-full' : 'w-36',
+          className,
+        )}
+        aria-label="Select theme"
+      >
+        <div className="flex items-center gap-2">
+          <ActiveIcon className="size-4" aria-hidden="true" />
+          <SelectValue placeholder="Theme" />
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {THEME_OPTIONS.map(({ value, label, Icon }) => (
+          <SelectItem key={value} value={value}>
+            <span className="flex items-center gap-2">
+              <Icon className="size-4" aria-hidden="true" />
+              {label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+

--- a/packages/ui/components/UserProfileRow.tsx
+++ b/packages/ui/components/UserProfileRow.tsx
@@ -74,7 +74,7 @@ export const UserProfileRow: React.FC<UserProfileRowProps> = ({
         >
           {profile.email}
           {isCurrentUser && (
-            <span className="ml-2 text-xs bg-white text-black px-2 py-1 rounded border border-black">
+            <span className="ml-2 text-xs bg-secondary text-secondary-foreground px-2 py-1 rounded border border-border">
               {t('you')}
             </span>
           )}

--- a/packages/ui/layouts/Layout.tsx
+++ b/packages/ui/layouts/Layout.tsx
@@ -34,13 +34,13 @@ export const Layout = () => {
   }, [setConversationOptions]);
 
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen bg-background text-foreground">
       <Header/>
       <main className="flex-grow">
         <Outlet/>
       </main>
       <Toaster/>
-      <footer className="p-4 bg-gray-100"/>
+      <footer className="p-4 bg-muted"/>
     </div>
   );
 };

--- a/packages/ui/pages/AuthPage.tsx
+++ b/packages/ui/pages/AuthPage.tsx
@@ -37,13 +37,13 @@ export const AuthPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4 sm:py-12 sm:px-6">
+    <div className="min-h-screen flex items-center justify-center bg-background py-8 px-4 sm:py-12 sm:px-6">
       <div className="w-full max-w-md space-y-6 sm:space-y-8">
         <header className="text-center">
-          <h1 className="text-2xl sm:text-3xl font-extrabold text-gray-900">
+          <h1 className="text-2xl sm:text-3xl font-extrabold text-foreground">
             {t('welcomeTo', { appName: app_name })}
           </h1>
-          <p className="mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600">
+          <p className="mt-1 sm:mt-2 text-xs sm:text-sm text-muted-foreground">
             {isSignIn ? t('signInToAccount') : t('createNewAccount')}
           </p>
         </header>

--- a/packages/ui/pages/EmailValidatedPage.tsx
+++ b/packages/ui/pages/EmailValidatedPage.tsx
@@ -8,11 +8,11 @@ export const EmailValidatedPage: React.FC = () => {
   const { t } = useTypedTranslation();
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
+    <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4">
       <div className="w-full max-w-md space-y-8 text-center">
         <Card className="p-6 w-full max-w-md space-y-4 text-center">
           <h2 className="text-2xl font-bold">{t('emailValidatedSuccess')}</h2>
-          <p className="text-sm text-gray-700">
+          <p className="text-sm text-muted-foreground">
             {t('emailValidatedMessage')}
           </p>
 

--- a/packages/ui/pages/HomePage.tsx
+++ b/packages/ui/pages/HomePage.tsx
@@ -17,13 +17,13 @@ export const HomePage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4 sm:py-12 sm:px-6">
+    <div className="min-h-screen flex items-center justify-center bg-background py-8 px-4 sm:py-12 sm:px-6">
       <div className="w-full max-w-md space-y-6 sm:space-y-8 text-center">
         <header>
-          <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900">
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-foreground">
             {t('welcomeTo', { appName: app_name })}
           </h1>
-          <p className="mt-2 sm:mt-4 text-lg sm:text-xl text-gray-600">
+          <p className="mt-2 sm:mt-4 text-lg sm:text-xl text-muted-foreground">
             {t('aiConversationPartner')}
           </p>
         </header>
@@ -31,30 +31,30 @@ export const HomePage: React.FC = () => {
         <div className="mt-8">
           {isAuthenticated ? (
             <div className="space-y-4">
-              <p className="text-lg text-gray-700">
+              <p className="text-lg text-muted-foreground">
                 {t('helloSignedIn', { name: user?.user_metadata?.full_name ?? user?.email })}
               </p>
               <Button
-                className="w-full py-4 sm:py-6 text-lg sm:text-xl bg-green-700 hover:bg-green-600 text-white"
+                className="w-full h-auto py-4 sm:py-6 text-lg sm:text-xl"
                 asChild>
                 <Link to="/chat">{t('goToPersonalitySelector')}</Link>
               </Button>
             </div>
           ) : (
             <div className="space-y-4">
-              <p className="text-lg text-gray-700">
+              <p className="text-lg text-muted-foreground">
                 {t('pleaseSignInMessage', { appName: app_name })}
               </p>
               <div className="flex flex-col space-y-4">
                 <Button
-                  className="w-full py-4 sm:py-6 text-lg sm:text-xl bg-green-700 hover:bg-green-600 text-white"
+                  className="w-full h-auto py-4 sm:py-6 text-lg sm:text-xl"
                   asChild
                 >
                   <Link to="/auth" state={{ isSignIn: true }}>
                     {t('signIn')}
                   </Link>
                 </Button>
-                <Button variant="outline" className="w-full py-4 sm:py-6 text-lg sm:text-xl" asChild>
+                <Button variant="outline" className="w-full h-auto py-4 sm:py-6 text-lg sm:text-xl" asChild>
                   <Link to="/auth" state={{ isSignIn: false }}>
                     {t('register')}
                   </Link>

--- a/packages/ui/pages/NotFoundPage.tsx
+++ b/packages/ui/pages/NotFoundPage.tsx
@@ -7,7 +7,7 @@ export function NotFoundPage() {
   const { t } = useTypedTranslation();
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+    <div className="flex items-center justify-center min-h-screen bg-background">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">{t('notFoundTitle')}</CardTitle>
@@ -16,7 +16,7 @@ export function NotFoundPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted-foreground">
             {t('notFoundMessage')}
           </p>
         </CardContent>

--- a/packages/ui/pages/chats/MessageChatPage.tsx
+++ b/packages/ui/pages/chats/MessageChatPage.tsx
@@ -602,7 +602,7 @@ export const MessageChatPage: React.FC = () => {
               {t('chat.chatWith', { name: personality.name })}
             </h1>
             <div className="flex items-center gap-2">
-              <Label htmlFor="audio-toggle" className="text-sm text-gray-600">
+              <Label htmlFor="audio-toggle" className="text-sm text-muted-foreground">
                 {audioEnabled ? t('chat.audioOn') : t('chat.audioOff')}
               </Label>
               <Switch
@@ -616,7 +616,7 @@ export const MessageChatPage: React.FC = () => {
           <PersonalityInfo
             personality={personality}
             conversationRole={conversationRoleName}
-            className="border-2 border-gray-400 rounded-lg p-6 mb-8"
+            className="border border-border rounded-lg p-6 mb-8 bg-card text-card-foreground"
           />
           <ScenarioInfo scenario={scenario}/>
         </div>
@@ -692,7 +692,7 @@ export const MessageChatPage: React.FC = () => {
         </div>
 
         {audioEnabled && (
-          <div className="mt-2 text-xs text-center text-gray-500">
+          <div className="mt-2 text-xs text-center text-muted-foreground">
             {t('chat.aiVoiceNote')}
           </div>
         )}

--- a/packages/ui/pages/chats/PersonalitySelectorPage.tsx
+++ b/packages/ui/pages/chats/PersonalitySelectorPage.tsx
@@ -161,10 +161,10 @@ export const PersonalitySelectorPage: React.FC = () => {
                         className="md:basis-1/2 lg:basis-1/2"
                       >
                         <Card
-                          className={`border-2 cursor-pointer transition-colors ${
+                          className={`cursor-pointer transition-colors border ${
                             selectedPersonality?.id === p.id ?
-                              'border-black' :
-                              'border-gray-300 hover:border-gray-600'
+                              'border-primary ring-2 ring-primary/40' :
+                              'border-border hover:border-primary/60'
                           }`}
                           onClick={() => selectPersonality(p)}
                         >
@@ -222,7 +222,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                         age: Number(e.target.value),
                       })
                     }
-                    className="bg-transparent border-2 border-gray-400"
+                    className="bg-background border border-border"
                     placeholder={t('personalityForm.placeholder.age')}
                   />
                 </div>
@@ -275,7 +275,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                     })
                   }
                   placeholder={t('personalityForm.placeholder.problem')}
-                  className="bg-transparent border-2 border-gray-400"
+                  className="bg-background border border-border"
                 />
               </div>
 
@@ -294,7 +294,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                     })
                   }
                   placeholder={t('personalityForm.placeholder.description')}
-                  className="bg-transparent border-2 border-gray-400 h-40"
+                  className="bg-background border border-border h-40"
                 />
               </div>
             </div>
@@ -313,7 +313,7 @@ export const PersonalitySelectorPage: React.FC = () => {
           {/* predefined scenario carousel */}
           <TabsContent value="predefined">
             {scenariosForPersonality.length === 0 ? (
-              <p className="text-gray-400 mb-10">{t('scenarios.noneForPersonality')}</p>
+              <p className="text-muted-foreground mb-10">{t('scenarios.noneForPersonality')}</p>
             ) : (
               <Carousel className="w-full mb-10">
                 <CarouselContent>
@@ -325,10 +325,10 @@ export const PersonalitySelectorPage: React.FC = () => {
                     return (
                       <CarouselItem key={s.id} className="md:basis-1/2 lg:basis-1/2">
                         <Card
-                          className={`border-2 cursor-pointer transition-colors ${
+                          className={`cursor-pointer transition-colors border ${
                             selectedScenario?.id === s.id ?
-                              'border-black' :
-                              'border-gray-300 hover:border-gray-600'
+                              'border-primary ring-2 ring-primary/40' :
+                              'border-border hover:border-primary/60'
                           }`}
                           onClick={() => setSelectedScenario(s)}
                         >
@@ -365,7 +365,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                       setting_en: e.target.value,
                     })
                   }
-                  className="bg-transparent border-2 border-gray-400"
+                  className="bg-background border border-border"
                   placeholder={t('scenarioForm.placeholder.setting')}
                 />
               </div>
@@ -383,7 +383,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                       situation_description_en: e.target.value,
                     })
                   }
-                  className="bg-transparent border-2 border-gray-400 h-40"
+                  className="bg-background border border-border h-40"
                   placeholder={t('scenarioForm.placeholder.description')}
                 />
               </div>
@@ -392,7 +392,7 @@ export const PersonalitySelectorPage: React.FC = () => {
 
           {/* no scenario chosen */}
           <TabsContent value="none">
-            <div className="mb-10 text-gray-500 italic">{t('scenarios.noneDescription')}</div>
+            <div className="mb-10 text-muted-foreground italic">{t('scenarios.noneDescription')}</div>
           </TabsContent>
         </Tabs>
 
@@ -409,9 +409,9 @@ export const PersonalitySelectorPage: React.FC = () => {
             isVoiceCallEnabled && (<Button
               onClick={() => storeAndNavigate('/voice-call')}
               disabled={isStartButtonDisabled()}
-              className="px-8 py-6 text-xl bg-green-700 hover:bg-green-600 text-white rounded-md flex items-center"
+              className="px-8 py-6 text-xl h-auto flex items-center gap-2"
             >
-              <span className="mr-2">{t('actions.startVoiceCall')}</span>
+              <span>{t('actions.startVoiceCall')}</span>
               <MdOutlinePhoneInTalk className="inline-block align-middle"/>
             </Button>
             )
@@ -420,9 +420,9 @@ export const PersonalitySelectorPage: React.FC = () => {
             isVideoCallEnabled && (<Button
               onClick={() => storeAndNavigate('/video-call')}
               disabled={isStartButtonDisabled()}
-              className="px-8 py-6 text-xl bg-green-700 hover:bg-green-600 text-white rounded-md flex items-center"
+              className="px-8 py-6 text-xl h-auto flex items-center gap-2"
             >
-              <span className="mr-2">{t('actions.startVideoCall')}</span>
+              <span>{t('actions.startVideoCall')}</span>
               <FaVideo/>
             </Button>)
           }
@@ -430,9 +430,9 @@ export const PersonalitySelectorPage: React.FC = () => {
             isMessageChatEnabled && <Button
               onClick={() => storeAndNavigate('/message-chat')}
               disabled={isStartButtonDisabled()}
-              className="px-8 py-6 text-xl bg-green-700 hover:bg-green-600 text-white rounded-md flex items-center"
+              className="px-8 py-6 text-xl h-auto flex items-center gap-2"
             >
-              <span className="mr-2">{t('actions.startMessageChat')}</span>
+              <span>{t('actions.startMessageChat')}</span>
               <IoMdSend size={20}/>
             </Button>
           }

--- a/packages/ui/pages/chats/VideoCallPage.tsx
+++ b/packages/ui/pages/chats/VideoCallPage.tsx
@@ -410,15 +410,15 @@ export const VideoCallPage: React.FC = () => {
 
   const [statusText, statusStyle] = (() => {
     if (!conversationStarted) {
-      return [t('readyToStart'), 'text-gray-600'] as [string, string];
+      return [t('readyToStart'), 'text-muted-foreground'] as [string, string];
     } else if (error) {
-      return [t('voiceDetectionErrorStatus'), 'text-red-600'];
+      return [t('voiceDetectionErrorStatus'), 'text-destructive'];
     } else if (isTranscribing) {
-      return [t('listeningToYou'), 'text-green-600'];
+      return [t('listeningToYou'), 'text-emerald-500 dark:text-emerald-300'];
     } else if (isAiProcessing) {
-      return [t('aiProcessing'), 'text-purple-600'];
+      return [t('aiProcessing'), 'text-primary'];
     } else {
-      return [t('readyWaitingForSpeech'), 'text-blue-600'];
+      return [t('readyWaitingForSpeech'), 'text-primary'];
     }
   })();
 
@@ -439,7 +439,7 @@ export const VideoCallPage: React.FC = () => {
         <span className={`font-bold ${statusStyle}`}>{statusText}</span>
       </p>
       {error && (
-        <p className="text-red-600 mt-2">
+        <p className="text-destructive mt-2">
           {error}
         </p>
       )}
@@ -460,11 +460,11 @@ export const VideoCallPage: React.FC = () => {
       mode="chat"
     >
 
-      <div className="w-full max-w-4xl mx-auto border-2 rounded-lg p-4 sm:p-8">
+      <div className="w-full max-w-4xl mx-auto border border-border rounded-lg p-4 sm:p-8 bg-card text-card-foreground">
         <h1 className="text-xl sm:text-3xl font-bold mb-4 sm:mb-6">{t('videoCall')}</h1>
 
         <div className="flex flex-col md:flex-row gap-4 sm:gap-6 mb-6 sm:mb-8">
-          <div className="flex-1 border-2 border-gray-400 rounded-lg p-4 relative"
+          <div className="flex-1 border border-border rounded-lg p-4 relative"
             style={{ maxHeight: '550px' }}>
             <AvatarTalkingHead ref={avatarRef} language={language} personality={personality}/>
           </div>
@@ -473,7 +473,7 @@ export const VideoCallPage: React.FC = () => {
             personality={personality}
             conversationRole={conversationRoleName}
             connectionStatus={connectionStatus}
-            className="flex-1 border-2 border-gray-400 rounded-lg p-4 sm:p-6"
+            className="flex-1 border border-border rounded-lg p-4 sm:p-6 bg-card text-card-foreground"
           />
         </div>
 
@@ -485,7 +485,7 @@ export const VideoCallPage: React.FC = () => {
           isProcessing={isAiProcessing}
           assistantName={personality.name}
           chatStyle="voice"
-          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border-2 border-gray-400 rounded-lg mb-6 sm:mb-8"
+          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border border-border rounded-lg mb-6 sm:mb-8 bg-card text-card-foreground"
           emptyStateMessage={emptyStateMessage}
           isConnected={isTranscribing}
         />
@@ -494,25 +494,26 @@ export const VideoCallPage: React.FC = () => {
           {!conversationStarted ? (
             <Button
               onClick={startConversation}
-              className="px-4 sm:px-8 py-3 sm:py-6 text-sm sm:text-xl bg-green-600 hover:bg-green-700 text-white rounded-md flex items-center"
+              className="px-4 sm:px-8 py-3 sm:py-6 text-sm sm:text-xl h-auto flex items-center gap-2"
               disabled={isAiProcessing}
             >
-              <span className="mr-2">{t('startConversation')}</span>
+              <span>{t('startConversation')}</span>
               <FaPlay className="inline-block align-middle"/>
             </Button>
           ) : (
             <Button
               onClick={handleEndCall}
-              className="px-4 sm:px-8 py-3 sm:py-6 text-sm sm:text-xl bg-red-600 hover:bg-red-700 text-white rounded-md flex items-center"
+              variant="destructive"
+              className="px-4 sm:px-8 py-3 sm:py-6 text-sm sm:text-xl h-auto flex items-center gap-2"
               disabled={isSavingConversation}
             >
-              <span className="mr-2">{t('endCall')}</span>
+              <span>{t('endCall')}</span>
               <MdCallEnd className="inline-block align-middle"/>
             </Button>
           )}
         </div>
 
-        <div className="mt-2 text-xs sm:text-sm text-center text-gray-500">
+        <div className="mt-2 text-xs sm:text-sm text-center text-muted-foreground">
           <div>
             {t('aiGeneratedNote')}
           </div>

--- a/packages/ui/pages/chats/VoiceCallPage.tsx
+++ b/packages/ui/pages/chats/VoiceCallPage.tsx
@@ -305,7 +305,7 @@ export const VoiceCallPage: React.FC = () => {
               personality={personality!}
               conversationRole={conversationRoleName}
               connectionStatus={connectionStatus}
-              className="border-2 border-gray-400 rounded-lg p-4 sm:p-6"
+              className="border border-border rounded-lg p-4 sm:p-6 bg-card text-card-foreground"
             />
           </div>
 
@@ -320,7 +320,7 @@ export const VoiceCallPage: React.FC = () => {
           assistantName={personality!.name}
           chatStyle="voice"
           isConnected={isConnected}
-          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border-2 border-gray-400 rounded-lg mb-6 sm:mb-8"
+          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border border-border rounded-lg mb-6 sm:mb-8 bg-card text-card-foreground"
         />
 
         <div className="flex justify-center gap-4">


### PR DESCRIPTION
## Summary
- wrap the web app with a next-themes provider and expose a shared ThemeProvider helper
- add a theme switcher component and surface it in the header for desktop and mobile views
- refresh page layouts and chat visuals to rely on semantic design tokens so dark mode renders correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9ecde1f9c83278c5b4ddc02f7b675