### PR TITLE
Add dark mode support with theme toggle

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,11 +1,16 @@
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import React from 'react';
 import { ROUTES } from '@repo/ui/routes/routes';
+import { ThemeProvider } from '@repo/ui/components/ThemeProvider';
 
 const router = createBrowserRouter(ROUTES);
 
 function App(): React.ReactElement<typeof RouterProvider> {
-  return <RouterProvider router={router}/>;
+  return (
+    <ThemeProvider>
+      <RouterProvider router={router}/>
+    </ThemeProvider>
+  );
 }
 
 export default App;

--- a/packages/frontend-utils/src/translation/locales/cs.json
+++ b/packages/frontend-utils/src/translation/locales/cs.json
@@ -93,6 +93,11 @@
   },
   "adminSection": "Admin sekce",
   "aiConversationPartner": "Váš konverzační partner s umělou inteligencí",
+  "appearance": {
+    "switchToDark": "Přepnout na tmavý režim",
+    "switchToLight": "Přepnout na světlý režim",
+    "toggle": "Přepnout vzhled"
+  },
   "aiGeneratedNote": "Poznámka: Hlas a animace avatara, které vidíte, jsou generovány umělou inteligencí.",
   "aiProcessing": "AI zpracovává...",
   "aiResponseError": "Omlouvám se, mám problém s odpovědí.",

--- a/packages/frontend-utils/src/translation/locales/en.json
+++ b/packages/frontend-utils/src/translation/locales/en.json
@@ -92,6 +92,11 @@
   },
   "adminSection": "Admin Section",
   "aiConversationPartner": "Your AI-powered conversation partner",
+  "appearance": {
+    "switchToDark": "Switch to dark mode",
+    "switchToLight": "Switch to light mode",
+    "toggle": "Toggle theme"
+  },
   "aiGeneratedNote": "Note: The voice and avatar animation you are seeing is AI-generated.",
   "aiProcessing": "AI is processing...",
   "aiResponseError": "Sorry, I'm having trouble responding right now.",

--- a/packages/ui/components/AuthForms.tsx
+++ b/packages/ui/components/AuthForms.tsx
@@ -292,7 +292,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
     return (
       <Card className="p-4 sm:p-6 w-full space-y-3 sm:space-y-4 text-center">
         <h2 className="text-xl sm:text-2xl font-bold">{t('thanksForRegistering')} 🎉</h2>
-        <p className="text-xs sm:text-sm text-gray-700">
+        <p className="text-xs sm:text-sm text-muted-foreground">
           {t('confirmationEmailSent')}
         </p>
 

--- a/packages/ui/components/AvatarTalkingHead.tsx
+++ b/packages/ui/components/AvatarTalkingHead.tsx
@@ -135,7 +135,7 @@ export const AvatarTalkingHead = forwardRef<
     <div
       ref={avatarContainerRef}
       style={{ maxHeight: '550px' }}
-      className="w-full h-full bg-gray-900 rounded-lg shadow-md"
+      className="w-full h-full rounded-lg shadow-md bg-secondary text-secondary-foreground"
     >
       {!isAvatarLoaded && (
         <div className="flex items-center justify-center h-full text-white">

--- a/packages/ui/components/ChatMessages.tsx
+++ b/packages/ui/components/ChatMessages.tsx
@@ -30,7 +30,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
   chatStyle = 'voice',
   isConnected = true,
   emptyStateMessage,
-  className = 'h-64 overflow-y-auto p-4 border-2 border-gray-400 rounded-lg',
+  className = 'h-64 overflow-y-auto p-4 border border-border rounded-lg bg-card text-card-foreground',
 }) => {
   const { t } = useTypedTranslation();
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -61,8 +61,8 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
           key={index}
           className={`p-3 rounded-lg ${
             msg.role === 'user' ?
-              'bg-blue-100 text-blue-800 ml-8' :
-              'bg-gray-100 text-gray-800 mr-8'
+              'bg-blue-100 text-blue-800 ml-8 dark:bg-primary dark:text-primary-foreground' :
+              'bg-gray-100 text-gray-800 mr-8 dark:bg-muted dark:text-muted-foreground'
           }`}
         >
           <div className="font-semibold mb-1">
@@ -73,7 +73,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
       ))}
 
       {currentTranscript && currentTranscript !== lastMessageContent && (
-        <div className="p-3 rounded-lg bg-blue-50 text-blue-800 ml-8 border border-blue-200">
+        <div className="p-3 rounded-lg bg-blue-50 text-blue-800 ml-8 border border-blue-200 dark:bg-primary/20 dark:text-primary-foreground dark:border-primary/60">
           <div className="font-semibold mb-1">
             {t('you')} ({t('listeningActive')})
           </div>
@@ -82,7 +82,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
       )}
 
       {assistantTranscript && (
-        <div className="p-3 rounded-lg bg-gray-50 text-gray-800 mr-8 border border-gray-200">
+        <div className="p-3 rounded-lg bg-gray-50 text-gray-800 mr-8 border border-gray-200 dark:bg-muted dark:text-muted-foreground dark:border-border">
           <div className="font-semibold mb-1">
             {assistantName} ({t('listeningActive')})
           </div>
@@ -91,16 +91,16 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
       )}
 
       {isProcessing && !currentTranscript && !assistantTranscript && (
-        <div className="bg-gray-100 text-gray-800 p-3 rounded-lg mr-8">
+        <div className="bg-gray-100 text-gray-800 p-3 rounded-lg mr-8 dark:bg-muted dark:text-muted-foreground">
           <div className="font-semibold mb-1">{t('aiProcessing')}</div>
           <div className="flex space-x-2">
-            <div className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"></div>
+            <div className="w-2 h-2 bg-gray-500 rounded-full animate-bounce dark:bg-muted-foreground"></div>
             <div
-              className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+              className="w-2 h-2 bg-gray-500 rounded-full animate-bounce dark:bg-muted-foreground"
               style={{ animationDelay: '0.2s' }}
             ></div>
             <div
-              className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+              className="w-2 h-2 bg-gray-500 rounded-full animate-bounce dark:bg-muted-foreground"
               style={{ animationDelay: '0.4s' }}
             ></div>
           </div>
@@ -119,8 +119,8 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
           <div
             className={`max-w-[70%] p-3 rounded-lg ${
               msg.role === 'user' ?
-                'bg-blue-500 text-white rounded-br-none' :
-                'bg-gray-200 text-gray-800 rounded-bl-none'
+                'bg-blue-500 text-white rounded-br-none dark:bg-primary dark:text-primary-foreground' :
+                'bg-gray-200 text-gray-800 rounded-bl-none dark:bg-muted dark:text-muted-foreground'
             }`}
           >
             <div className="flex justify-between items-start">
@@ -128,7 +128,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
               {msg.role === 'assistant' && msg.audioUrl && onPlayAudio && (
                 <button
                   onClick={() => onPlayAudio(msg, index)}
-                  className="ml-1 p-1 rounded-full hover:bg-gray-300 transition-colors"
+                  className="ml-1 p-1 rounded-full hover:bg-gray-300 dark:hover:bg-muted transition-colors"
                   title={
                     isAudioPlaying ? t('chat.stopRecording') : t('chat.startRecording')
                   }
@@ -146,7 +146,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
             {msg.timestamp && (
               <p
                 className={`text-xs mt-1 ${
-                  msg.role === 'user' ? 'text-blue-100' : 'text-gray-500'
+                  msg.role === 'user' ? 'text-blue-100 dark:text-primary-foreground' : 'text-gray-500 dark:text-muted-foreground'
                 }`}
               >
                 {msg.timestamp.toLocaleTimeString([], {
@@ -161,18 +161,18 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 
       {isAiTyping && (
         <div className="flex justify-start">
-          <div className="bg-gray-200 text-gray-800 p-3 rounded-lg rounded-bl-none max-w-[70%]">
+          <div className="bg-gray-200 text-gray-800 p-3 rounded-lg rounded-bl-none max-w-[70%] dark:bg-muted dark:text-muted-foreground">
             <div className="flex space-x-1">
               <div
-                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce dark:bg-muted-foreground"
                 style={{ animationDelay: '0s' }}
               ></div>
               <div
-                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce dark:bg-muted-foreground"
                 style={{ animationDelay: '0.2s' }}
               ></div>
               <div
-                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce"
+                className="w-2 h-2 bg-gray-500 rounded-full animate-bounce dark:bg-muted-foreground"
                 style={{ animationDelay: '0.4s' }}
               ></div>
             </div>
@@ -188,7 +188,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
             !currentTranscript &&
             !assistantTranscript &&
             !isAiTyping ? (
-          <div className="text-gray-500 text-center py-8">
+          <div className="text-gray-500 dark:text-muted-foreground text-center py-8">
             {emptyStateMessage || defaultEmptyStateMessage}
           </div>
         ) : chatStyle === 'voice' ? (

--- a/packages/ui/components/ConversationRoleSelector.tsx
+++ b/packages/ui/components/ConversationRoleSelector.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { useTypedTranslation } from '../hooks/useTypedTranslation';
 import { LANGUAGE } from '@repo/shared/enums/Language';
+import { cn } from '../lib/utils';
 
 /**
  * Props for the role selector (rewritten to work with role **names**, not objects).
@@ -52,7 +53,8 @@ export const ConversationRoleSelector: React.FC<ConversationRoleSelectorProps> =
           <Button
             key={conversationRole.id}
             variant={isSelected ? 'default' : 'outline'}
-            className={isSelected ? 'bg-gray-800 text-white hover:bg-gray-700' : 'border-gray-500 hover:bg-gray-700'}
+            className="transition-colors"
+            aria-pressed={isSelected}
             onClick={() => selectUserRole(conversationRole)}
           >
             {name}
@@ -65,7 +67,7 @@ export const ConversationRoleSelector: React.FC<ConversationRoleSelectorProps> =
           id="custom-user-role"
           value={customRoleName}
           onChange={handleCustomUserRoleChange}
-          className={`bg-transparent border-2 ${customRoleName ? 'border-black' : 'border-gray-400'}`}
+          className={cn(customRoleName ? 'border-primary' : 'border-border')}
           placeholder={t('enterCustomRolePlaceholder')}
         />
       </div>

--- a/packages/ui/components/ConversationTranscriptDialog.tsx
+++ b/packages/ui/components/ConversationTranscriptDialog.tsx
@@ -149,14 +149,14 @@ export const ConversationTranscriptDialog: React.FC<ConversationTranscriptDialog
           )}
 
           {mode === 'chat' && (description || defaultDescription) && (
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               {description || defaultDescription}
             </p>
           )}
         </DialogHeader>
 
         {mode === 'chat' && endedDueToTimeLimit && (
-          <div className="mb-4 p-3 bg-yellow-100 text-yellow-800 rounded-lg">
+          <div className="mb-4 p-3 rounded-lg bg-yellow-100 text-yellow-800 dark:bg-yellow-200/20 dark:text-yellow-200">
             {t('chat.timeLimit', {
               defaultValue: 'Chat ended after reaching the 5-minute time limit.',
             })}
@@ -164,14 +164,14 @@ export const ConversationTranscriptDialog: React.FC<ConversationTranscriptDialog
         )}
 
         {mode === 'chat' && isSavingConversation && (
-          <div className="mb-4 p-3 bg-blue-100 text-blue-800 rounded-lg">
+          <div className="mb-4 p-3 rounded-lg bg-primary/15 text-primary dark:bg-primary/30 dark:text-primary-foreground">
             {t('chat.savingConversation', {
               defaultValue: 'Saving conversation...',
             })}
           </div>
         )}
 
-        <ScrollArea className="flex-1 max-h-[60vh] p-4 border rounded-lg">
+        <ScrollArea className="flex-1 max-h-[60vh] p-4 border border-border rounded-lg bg-card text-card-foreground">
           {messages && messages.length > 0 ? (
             messages.map((msg, index) => (
               <div key={index} className={`mb-4 ${msg.role === 'assistant' ? 'pr-4' : 'pl-4'}`}>
@@ -187,10 +187,8 @@ export const ConversationTranscriptDialog: React.FC<ConversationTranscriptDialog
                   msg.role === 'assistant' ?
                     mode === 'admin' ?
                       'bg-muted text-foreground' :
-                      'bg-gray-100 text-gray-800' :
-                    mode === 'admin' ?
-                      'bg-primary/10 text-foreground' :
-                      'bg-blue-100 text-blue-800'
+                      'bg-muted text-muted-foreground' :
+                    'bg-primary text-primary-foreground'
                 }`}>
                   {msg.content}
                 </p>

--- a/packages/ui/components/Header.tsx
+++ b/packages/ui/components/Header.tsx
@@ -11,6 +11,8 @@ import { useAppStore } from '../hooks/useAppStore';
 import { isProfileAdmin } from '@repo/shared/utils/access';
 import { useTypedTranslation } from '../hooks/useTypedTranslation';
 import { createInitials } from '@repo/shared/utils/usernameUtils';
+import { ThemeToggle } from './ThemeToggle';
+import { cn } from '../lib/utils';
 
 export function Header() {
   const { i18n } = useTypedTranslation();
@@ -39,8 +41,8 @@ export function Header() {
   };
 
   return (
-    <header className="py-4 px-4 sm:px-6 shadow-md mb-4">
-      <div className="container mx-auto flex justify-between items-center">
+    <header className="py-4 px-4 sm:px-6 shadow-sm mb-4 bg-background text-foreground border-b border-border/60">
+      <div className="container mx-auto flex justify-between items-center gap-4">
         <h1 className="text-2xl font-bold">
           <Link to="/">{app_name}</Link>
         </h1>
@@ -56,6 +58,8 @@ export function Header() {
             onChange={handleLanguageChange}
             compact
           />
+
+          <ThemeToggle/>
 
           {!isSignedIn && ready && (
             <AuthButtons/>
@@ -86,6 +90,8 @@ export function Header() {
             }}
           />
 
+          <ThemeToggle fullWidth/>
+
           {!isSignedIn && ready && (
             <AuthButtons fullWidth onAnyClick={() => setMenuOpen(false)}/>
           )}
@@ -113,13 +119,14 @@ export function Header() {
 
 const BurgerButton: React.FC<{ open: boolean; onToggle: () => void }> = ({ open, onToggle }) => (
   <button
-    className="sm:hidden flex flex-col justify-center items-center w-10 h-10 rounded focus:outline-none"
+    className="sm:hidden flex flex-col justify-center items-center w-10 h-10 rounded-md border border-border/60 bg-card text-foreground focus:outline-none"
     aria-label={open ? 'Close menu' : 'Open menu'}
+    aria-expanded={open}
     onClick={onToggle}
   >
-    <span className={`block w-6 h-0.5 bg-black mb-1 transition-all ${open ? 'rotate-45 translate-y-1.5' : ''}`}/>
-    <span className={`block w-6 h-0.5 bg-black mb-1 transition-all ${open ? 'opacity-0' : ''}`}/>
-    <span className={`block w-6 h-0.5 bg-black transition-all ${open ? '-rotate-45 -translate-y-1.5' : ''}`}/>
+    <span className={`block w-6 h-0.5 bg-foreground mb-1 transition-all ${open ? 'rotate-45 translate-y-1.5' : ''}`}/>
+    <span className={`block w-6 h-0.5 bg-foreground mb-1 transition-all ${open ? 'opacity-0' : ''}`}/>
+    <span className={`block w-6 h-0.5 bg-foreground transition-all ${open ? '-rotate-45 -translate-y-1.5' : ''}`}/>
   </button>
 );
 
@@ -135,14 +142,18 @@ const LanguageSelector: React.FC<{
   return (
     <Select value={currentLang.ISO639} onValueChange={onChange}>
       <SelectTrigger
-        className={`${compact ? 'w-24' : 'w-full'} bg-white ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+        className={cn(
+          compact ? 'w-24' : 'w-full',
+          'bg-background dark:bg-input/30',
+          disabled && 'opacity-60 cursor-not-allowed',
+        )}
         disabled={disabled}
         title={disabled ? (t?.('languageChangeDisabledInChat') ?? 'Language change is disabled inside a chat thread.') : undefined}
         aria-disabled={disabled}
       >
         <SelectValue placeholder={currentLang.NATIVE_NAME.toUpperCase()}/>
       </SelectTrigger>
-      <SelectContent className="bg-white">
+      <SelectContent className="bg-popover text-popover-foreground">
         {availableLangs.map((lang) => (
           <SelectItem key={lang.ISO639} value={lang.ISO639} disabled={disabled}>
             {lang.NATIVE_NAME} {lang.ISO639 === 'sk' ? t('slovakLanguageNote') : ''}
@@ -216,13 +227,13 @@ const MobileMenuDrawer: React.FC<{
 }> = ({ open, onClose, children }) => {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 sm:hidden" onClick={onClose}>
+    <div className="fixed inset-0 z-50 bg-black/40 sm:hidden" onClick={onClose}>
       <div
-        className="absolute top-0 right-0 w-64 h-full bg-white shadow-lg p-4 flex flex-col gap-4"
+        className="absolute top-0 right-0 w-64 h-full bg-card text-card-foreground border-l border-border shadow-lg p-4 flex flex-col gap-4"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-end">
-          <button className="text-2xl font-bold" aria-label="Close menu" onClick={onClose}>
+          <button className="text-2xl font-bold text-foreground" aria-label="Close menu" onClick={onClose}>
                         &times;
           </button>
         </div>

--- a/packages/ui/components/PersonalityInfo.tsx
+++ b/packages/ui/components/PersonalityInfo.tsx
@@ -14,7 +14,7 @@ export const PersonalityInfo: React.FC<PersonalityInfoProps> = ({
   personality,
   conversationRole,
   connectionStatus,
-  className = 'border-2 border-gray-400 rounded-lg p-6',
+  className = 'rounded-lg border border-border bg-card p-6 text-card-foreground',
 }) => {
   const { t, language } = useTypedTranslation();
   const problemSummary = language === LANGUAGE.EN ? personality.problem_summary_en : personality.problem_summary_cs;

--- a/packages/ui/components/ResetPasswordRequestForm.tsx
+++ b/packages/ui/components/ResetPasswordRequestForm.tsx
@@ -37,10 +37,10 @@ export const ResetPasswordRequestForm: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4 sm:py-12 sm:px-6">
+    <div className="min-h-screen flex items-center justify-center bg-background py-8 px-4 sm:py-12 sm:px-6">
 
       <Card className="p-4 sm:p-6 w-full max-w-md">
-        <h2 className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 text-center">
+        <h2 className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 text-center text-foreground">
           {t('forgotPassword', 'Forgot your password?')}
         </h2>
 

--- a/packages/ui/components/ScenarioInfo.tsx
+++ b/packages/ui/components/ScenarioInfo.tsx
@@ -15,7 +15,7 @@ export const ScenarioInfo: React.FC<ScenarioInfoProps> = ({
 
   if (!scenario) {
     return (
-      <div className="flex-1 border-2 border-gray-400 rounded-lg p-6 bg-gray-50">
+      <div className="flex-1 rounded-lg border border-border bg-card p-6 text-card-foreground">
         <h2 className="text-xl font-semibold mb-2">{t('scenario')}</h2>
         <p className="text-sm">{t('noScenarioSelected')}</p>
       </div>
@@ -24,7 +24,7 @@ export const ScenarioInfo: React.FC<ScenarioInfoProps> = ({
   const { situationDescription, setting } = universalDescriptionForScenario(scenario, language);
 
   return (
-    <div className="flex-1 border-2 border-gray-400 rounded-lg p-6 bg-gray-50">
+    <div className="flex-1 rounded-lg border border-border bg-card p-6 text-card-foreground">
       <h2 className="text-xl font-semibold mb-2">{t('scenario')}</h2>
       {setting && <p className="italic text-sm mb-1">{setting}</p>}
       <p className="text-sm whitespace-pre-wrap">

--- a/packages/ui/components/ThemeProvider.tsx
+++ b/packages/ui/components/ThemeProvider.tsx
@@ -1,0 +1,103 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+    theme: Theme;
+    setTheme: (theme: Theme) => void;
+    toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'ai-conversation-partner-theme';
+
+const applyThemeToDocument = (theme: Theme) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.dataset.theme = theme;
+};
+
+const getInitialTheme = (): Theme => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') {
+    applyThemeToDocument(stored);
+    return stored;
+  }
+
+  const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+  const theme = mediaQuery?.matches ? 'dark' : 'light';
+  applyThemeToDocument(theme);
+  return theme;
+};
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+  const [hasStoredPreference, setHasStoredPreference] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored === 'light' || stored === 'dark';
+  });
+
+  useEffect(() => {
+    applyThemeToDocument(theme);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const listener = (event: MediaQueryListEvent) => {
+      if (!hasStoredPreference) {
+        setThemeState(event.matches ? 'dark' : 'light');
+      }
+    };
+
+    mediaQuery.addEventListener('change', listener);
+    return () => mediaQuery.removeEventListener('change', listener);
+  }, [hasStoredPreference]);
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    setHasStoredPreference(true);
+    setThemeState(newTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setHasStoredPreference(true);
+    setThemeState((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/packages/ui/components/ThemeToggle.tsx
+++ b/packages/ui/components/ThemeToggle.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { Button } from './ui/button';
+import { cn } from '../lib/utils';
+import { useTheme } from './ThemeProvider';
+import { useTypedTranslation } from '../hooks/useTypedTranslation';
+
+interface ThemeToggleProps {
+    className?: string;
+    fullWidth?: boolean;
+    onToggle?: () => void;
+}
+
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className, fullWidth, onToggle }) => {
+  const { theme, toggleTheme } = useTheme();
+  const { t } = useTypedTranslation();
+  const isDark = theme === 'dark';
+  const Icon = isDark ? Sun : Moon;
+
+  const handleClick = () => {
+    toggleTheme();
+    onToggle?.();
+  };
+
+  const label = isDark ? t('appearance.switchToLight') : t('appearance.switchToDark');
+
+  if (fullWidth) {
+    return (
+      <Button
+        variant="outline"
+        className={cn('w-full justify-between', className)}
+        onClick={handleClick}
+        type="button"
+      >
+        <span className="flex items-center gap-2">
+          <Icon className="size-4"/>
+          {label}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {t('appearance.toggle')}
+        </span>
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      className={cn('rounded-full', className)}
+      onClick={handleClick}
+      aria-label={t('appearance.toggle')}
+      type="button"
+    >
+      <Icon className="size-4"/>
+      <span className="sr-only">{label}</span>
+    </Button>
+  );
+};

--- a/packages/ui/components/UserProfileRow.tsx
+++ b/packages/ui/components/UserProfileRow.tsx
@@ -74,7 +74,7 @@ export const UserProfileRow: React.FC<UserProfileRowProps> = ({
         >
           {profile.email}
           {isCurrentUser && (
-            <span className="ml-2 text-xs bg-white text-black px-2 py-1 rounded border border-black">
+            <span className="ml-2 text-xs px-2 py-1 rounded border border-border/60 bg-accent text-accent-foreground">
               {t('you')}
             </span>
           )}

--- a/packages/ui/layouts/Layout.tsx
+++ b/packages/ui/layouts/Layout.tsx
@@ -34,13 +34,13 @@ export const Layout = () => {
   }, [setConversationOptions]);
 
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen bg-background text-foreground">
       <Header/>
       <main className="flex-grow">
         <Outlet/>
       </main>
       <Toaster/>
-      <footer className="p-4 bg-gray-100"/>
+      <footer className="p-4 border-t border-border bg-muted text-muted-foreground"/>
     </div>
   );
 };

--- a/packages/ui/pages/AuthPage.tsx
+++ b/packages/ui/pages/AuthPage.tsx
@@ -37,13 +37,13 @@ export const AuthPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4 sm:py-12 sm:px-6">
-      <div className="w-full max-w-md space-y-6 sm:space-y-8">
-        <header className="text-center">
-          <h1 className="text-2xl sm:text-3xl font-extrabold text-gray-900">
+    <div className="min-h-screen flex items-center justify-center bg-background py-8 px-4 sm:py-12 sm:px-6">
+      <div className="w-full max-w-md space-y-6 sm:space-y-8 rounded-xl border border-border/60 bg-card p-6 sm:p-8 shadow-sm">
+        <header className="text-center text-card-foreground">
+          <h1 className="text-2xl sm:text-3xl font-extrabold text-foreground">
             {t('welcomeTo', { appName: app_name })}
           </h1>
-          <p className="mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600">
+          <p className="mt-1 sm:mt-2 text-xs sm:text-sm text-muted-foreground">
             {isSignIn ? t('signInToAccount') : t('createNewAccount')}
           </p>
         </header>

--- a/packages/ui/pages/EmailValidatedPage.tsx
+++ b/packages/ui/pages/EmailValidatedPage.tsx
@@ -8,11 +8,11 @@ export const EmailValidatedPage: React.FC = () => {
   const { t } = useTypedTranslation();
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
+    <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4">
       <div className="w-full max-w-md space-y-8 text-center">
         <Card className="p-6 w-full max-w-md space-y-4 text-center">
-          <h2 className="text-2xl font-bold">{t('emailValidatedSuccess')}</h2>
-          <p className="text-sm text-gray-700">
+          <h2 className="text-2xl font-bold text-foreground">{t('emailValidatedSuccess')}</h2>
+          <p className="text-sm text-muted-foreground">
             {t('emailValidatedMessage')}
           </p>
 

--- a/packages/ui/pages/HomePage.tsx
+++ b/packages/ui/pages/HomePage.tsx
@@ -17,13 +17,13 @@ export const HomePage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8 px-4 sm:py-12 sm:px-6">
-      <div className="w-full max-w-md space-y-6 sm:space-y-8 text-center">
+    <div className="min-h-screen flex items-center justify-center bg-background py-8 px-4 sm:py-12 sm:px-6">
+      <div className="w-full max-w-md space-y-6 sm:space-y-8 text-center rounded-xl border border-border/60 bg-card p-6 sm:p-8 shadow-sm">
         <header>
-          <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900">
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-foreground">
             {t('welcomeTo', { appName: app_name })}
           </h1>
-          <p className="mt-2 sm:mt-4 text-lg sm:text-xl text-gray-600">
+          <p className="mt-2 sm:mt-4 text-lg sm:text-xl text-muted-foreground">
             {t('aiConversationPartner')}
           </p>
         </header>
@@ -31,7 +31,7 @@ export const HomePage: React.FC = () => {
         <div className="mt-8">
           {isAuthenticated ? (
             <div className="space-y-4">
-              <p className="text-lg text-gray-700">
+              <p className="text-lg text-muted-foreground">
                 {t('helloSignedIn', { name: user?.user_metadata?.full_name ?? user?.email })}
               </p>
               <Button
@@ -42,7 +42,7 @@ export const HomePage: React.FC = () => {
             </div>
           ) : (
             <div className="space-y-4">
-              <p className="text-lg text-gray-700">
+              <p className="text-lg text-muted-foreground">
                 {t('pleaseSignInMessage', { appName: app_name })}
               </p>
               <div className="flex flex-col space-y-4">

--- a/packages/ui/pages/NotFoundPage.tsx
+++ b/packages/ui/pages/NotFoundPage.tsx
@@ -7,7 +7,7 @@ export function NotFoundPage() {
   const { t } = useTypedTranslation();
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+    <div className="flex items-center justify-center min-h-screen bg-background">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">{t('notFoundTitle')}</CardTitle>
@@ -16,7 +16,7 @@ export function NotFoundPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted-foreground">
             {t('notFoundMessage')}
           </p>
         </CardContent>

--- a/packages/ui/pages/chats/MessageChatPage.tsx
+++ b/packages/ui/pages/chats/MessageChatPage.tsx
@@ -595,14 +595,14 @@ export const MessageChatPage: React.FC = () => {
       mode="chat"
     >
 
-      <div className="w-full max-w-4xl mx-auto border-2 rounded-lg p-4 sm:p-8 flex flex-col flex-grow">
-        <div className="border-b-2 pb-4 mb-4">
+      <div className="w-full max-w-4xl mx-auto border border-border rounded-lg bg-card p-4 sm:p-8 flex flex-col flex-grow text-card-foreground">
+        <div className="border-b border-border pb-4 mb-4">
           <div className="flex justify-between items-center mb-2">
             <h1 className="text-3xl font-bold">
               {t('chat.chatWith', { name: personality.name })}
             </h1>
             <div className="flex items-center gap-2">
-              <Label htmlFor="audio-toggle" className="text-sm text-gray-600">
+              <Label htmlFor="audio-toggle" className="text-sm text-muted-foreground">
                 {audioEnabled ? t('chat.audioOn') : t('chat.audioOff')}
               </Label>
               <Switch
@@ -616,7 +616,7 @@ export const MessageChatPage: React.FC = () => {
           <PersonalityInfo
             personality={personality}
             conversationRole={conversationRoleName}
-            className="border-2 border-gray-400 rounded-lg p-6 mb-8"
+            className="mb-8 rounded-lg border border-border bg-card p-6 text-card-foreground"
           />
           <ScenarioInfo scenario={scenario}/>
         </div>
@@ -628,7 +628,7 @@ export const MessageChatPage: React.FC = () => {
           onPlayAudio={playMessageAudio}
           isAudioPlaying={isAudioPlaying}
           chatStyle="text"
-          className="flex-grow overflow-y-auto mb-4 p-3 border rounded-md"
+          className="flex-grow overflow-y-auto mb-4 p-3 border border-border rounded-md bg-card text-card-foreground"
         />
 
         <div className="flex items-center">
@@ -692,7 +692,7 @@ export const MessageChatPage: React.FC = () => {
         </div>
 
         {audioEnabled && (
-          <div className="mt-2 text-xs text-center text-gray-500">
+          <div className="mt-2 text-xs text-center text-muted-foreground">
             {t('chat.aiVoiceNote')}
           </div>
         )}

--- a/packages/ui/pages/chats/PersonalitySelectorPage.tsx
+++ b/packages/ui/pages/chats/PersonalitySelectorPage.tsx
@@ -128,8 +128,8 @@ export const PersonalitySelectorPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen p-6 flex flex-col items-center">
-      <div className="w-full max-w-4xl mx-auto border-2 rounded-lg p-8">
+    <div className="min-h-screen p-6 flex flex-col items-center bg-background text-foreground">
+      <div className="w-full max-w-4xl mx-auto border border-border rounded-lg bg-card p-6 sm:p-8 text-card-foreground">
         <h1 className="text-3xl font-bold mb-6">{t('hello')}</h1>
         <h2 className="text-2xl mb-8">{t('selectAvatarPersonality')}</h2>
 
@@ -161,10 +161,10 @@ export const PersonalitySelectorPage: React.FC = () => {
                         className="md:basis-1/2 lg:basis-1/2"
                       >
                         <Card
-                          className={`border-2 cursor-pointer transition-colors ${
+                          className={`cursor-pointer transition-colors rounded-xl border ${
                             selectedPersonality?.id === p.id ?
-                              'border-black' :
-                              'border-gray-300 hover:border-gray-600'
+                              'border-primary ring-2 ring-primary/40' :
+                              'border-border hover:border-primary/60'
                           }`}
                           onClick={() => selectPersonality(p)}
                         >
@@ -222,7 +222,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                         age: Number(e.target.value),
                       })
                     }
-                    className="bg-transparent border-2 border-gray-400"
+                    className="border-border"
                     placeholder={t('personalityForm.placeholder.age')}
                   />
                 </div>
@@ -275,7 +275,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                     })
                   }
                   placeholder={t('personalityForm.placeholder.problem')}
-                  className="bg-transparent border-2 border-gray-400"
+                  className="border-border"
                 />
               </div>
 
@@ -294,7 +294,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                     })
                   }
                   placeholder={t('personalityForm.placeholder.description')}
-                  className="bg-transparent border-2 border-gray-400 h-40"
+                  className="h-40 border border-border"
                 />
               </div>
             </div>
@@ -313,7 +313,7 @@ export const PersonalitySelectorPage: React.FC = () => {
           {/* predefined scenario carousel */}
           <TabsContent value="predefined">
             {scenariosForPersonality.length === 0 ? (
-              <p className="text-gray-400 mb-10">{t('scenarios.noneForPersonality')}</p>
+              <p className="text-muted-foreground mb-10">{t('scenarios.noneForPersonality')}</p>
             ) : (
               <Carousel className="w-full mb-10">
                 <CarouselContent>
@@ -325,10 +325,10 @@ export const PersonalitySelectorPage: React.FC = () => {
                     return (
                       <CarouselItem key={s.id} className="md:basis-1/2 lg:basis-1/2">
                         <Card
-                          className={`border-2 cursor-pointer transition-colors ${
+                          className={`cursor-pointer transition-colors rounded-xl border ${
                             selectedScenario?.id === s.id ?
-                              'border-black' :
-                              'border-gray-300 hover:border-gray-600'
+                              'border-primary ring-2 ring-primary/40' :
+                              'border-border hover:border-primary/60'
                           }`}
                           onClick={() => setSelectedScenario(s)}
                         >
@@ -365,7 +365,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                       setting_en: e.target.value,
                     })
                   }
-                  className="bg-transparent border-2 border-gray-400"
+                  className="border-border"
                   placeholder={t('scenarioForm.placeholder.setting')}
                 />
               </div>
@@ -383,7 +383,7 @@ export const PersonalitySelectorPage: React.FC = () => {
                       situation_description_en: e.target.value,
                     })
                   }
-                  className="bg-transparent border-2 border-gray-400 h-40"
+                  className="h-40 border border-border"
                   placeholder={t('scenarioForm.placeholder.description')}
                 />
               </div>
@@ -392,7 +392,7 @@ export const PersonalitySelectorPage: React.FC = () => {
 
           {/* no scenario chosen */}
           <TabsContent value="none">
-            <div className="mb-10 text-gray-500 italic">{t('scenarios.noneDescription')}</div>
+            <div className="mb-10 italic text-muted-foreground">{t('scenarios.noneDescription')}</div>
           </TabsContent>
         </Tabs>
 

--- a/packages/ui/pages/chats/VideoCallPage.tsx
+++ b/packages/ui/pages/chats/VideoCallPage.tsx
@@ -410,7 +410,7 @@ export const VideoCallPage: React.FC = () => {
 
   const [statusText, statusStyle] = (() => {
     if (!conversationStarted) {
-      return [t('readyToStart'), 'text-gray-600'] as [string, string];
+      return [t('readyToStart'), 'text-muted-foreground'] as [string, string];
     } else if (error) {
       return [t('voiceDetectionErrorStatus'), 'text-red-600'];
     } else if (isTranscribing) {
@@ -460,11 +460,11 @@ export const VideoCallPage: React.FC = () => {
       mode="chat"
     >
 
-      <div className="w-full max-w-4xl mx-auto border-2 rounded-lg p-4 sm:p-8">
+      <div className="w-full max-w-4xl mx-auto border border-border rounded-lg bg-card p-4 sm:p-8 text-card-foreground">
         <h1 className="text-xl sm:text-3xl font-bold mb-4 sm:mb-6">{t('videoCall')}</h1>
 
         <div className="flex flex-col md:flex-row gap-4 sm:gap-6 mb-6 sm:mb-8">
-          <div className="flex-1 border-2 border-gray-400 rounded-lg p-4 relative"
+          <div className="flex-1 border border-border rounded-lg bg-card p-4 relative"
             style={{ maxHeight: '550px' }}>
             <AvatarTalkingHead ref={avatarRef} language={language} personality={personality}/>
           </div>
@@ -473,7 +473,7 @@ export const VideoCallPage: React.FC = () => {
             personality={personality}
             conversationRole={conversationRoleName}
             connectionStatus={connectionStatus}
-            className="flex-1 border-2 border-gray-400 rounded-lg p-4 sm:p-6"
+            className="flex-1 rounded-lg border border-border bg-card p-4 sm:p-6 text-card-foreground"
           />
         </div>
 
@@ -485,7 +485,7 @@ export const VideoCallPage: React.FC = () => {
           isProcessing={isAiProcessing}
           assistantName={personality.name}
           chatStyle="voice"
-          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border-2 border-gray-400 rounded-lg mb-6 sm:mb-8"
+          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border border-border rounded-lg mb-6 sm:mb-8 bg-card text-card-foreground"
           emptyStateMessage={emptyStateMessage}
           isConnected={isTranscribing}
         />
@@ -512,7 +512,7 @@ export const VideoCallPage: React.FC = () => {
           )}
         </div>
 
-        <div className="mt-2 text-xs sm:text-sm text-center text-gray-500">
+        <div className="mt-2 text-xs sm:text-sm text-center text-muted-foreground">
           <div>
             {t('aiGeneratedNote')}
           </div>

--- a/packages/ui/pages/chats/VoiceCallPage.tsx
+++ b/packages/ui/pages/chats/VoiceCallPage.tsx
@@ -296,7 +296,7 @@ export const VoiceCallPage: React.FC = () => {
       onGoToPersonalitySelector={handleGoToPersonalitySelector}
       mode="chat"
     >
-      <div className="w-full max-w-4xl mx-auto border-2 rounded-lg p-4 sm:p-8">
+      <div className="w-full max-w-4xl mx-auto border border-border rounded-lg bg-card p-4 sm:p-8 text-card-foreground">
         <h1 className="text-xl sm:text-3xl font-bold mb-4 sm:mb-6">{t('voiceCall')}</h1>
 
         <div className="flex flex-col md:flex-row gap-4 sm:gap-6 mb-6 sm:mb-8">
@@ -305,7 +305,7 @@ export const VoiceCallPage: React.FC = () => {
               personality={personality!}
               conversationRole={conversationRoleName}
               connectionStatus={connectionStatus}
-              className="border-2 border-gray-400 rounded-lg p-4 sm:p-6"
+              className="rounded-lg border border-border bg-card p-4 sm:p-6 text-card-foreground"
             />
           </div>
 
@@ -320,7 +320,7 @@ export const VoiceCallPage: React.FC = () => {
           assistantName={personality!.name}
           chatStyle="voice"
           isConnected={isConnected}
-          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border-2 border-gray-400 rounded-lg mb-6 sm:mb-8"
+          className="h-48 sm:h-64 overflow-y-auto p-3 sm:p-4 border border-border rounded-lg mb-6 sm:mb-8 bg-card text-card-foreground"
         />
 
         <div className="flex justify-center gap-4">


### PR DESCRIPTION
## Summary
- add a theme provider and toggle to persist light/dark mode and wrap the router
- integrate the theme switcher in the header with new translations and menu updates
- restyle key pages and chat components to use theme-aware tokens so dark mode looks consistent

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9ecde1f9c83278c5b4ddc02f7b675